### PR TITLE
Play / Pause media controls from remote controller

### DIFF
--- a/app/src/main/java/free/rm/skytube/businessobjects/interfaces/PlaybackStateListener.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/interfaces/PlaybackStateListener.java
@@ -1,0 +1,7 @@
+package free.rm.skytube.businessobjects.interfaces;
+
+public interface PlaybackStateListener {
+    void started();
+    void paused();
+    void ended();
+}

--- a/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
@@ -37,4 +37,6 @@ public interface YouTubePlayerFragmentInterface {
 	 * Start playback of current video.
 	 */
 	void play();
+
+	void setPlaybackStateListener(PlaybackStateListener listener);
 }

--- a/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
@@ -23,6 +23,12 @@ public interface YouTubePlayerFragmentInterface {
 	int getCurrentVideoPosition();
 
 	/**
+	 * Whether the current video is playing.
+	 * @return boolean
+	 */
+	boolean isPlaying();
+
+	/**
 	 * Pause the currently playing video.
 	 */
 	void pause();

--- a/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
+++ b/app/src/main/java/free/rm/skytube/businessobjects/interfaces/YouTubePlayerFragmentInterface.java
@@ -26,4 +26,9 @@ public interface YouTubePlayerFragmentInterface {
 	 * Pause the currently playing video.
 	 */
 	void pause();
+
+	/**
+	 * Start playback of current video.
+	 */
+	void play();
 }

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -52,14 +52,17 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 
 	private FragmentEx videoPlayerFragment;
 	private YouTubePlayerFragmentInterface fragmentListener;
-	private YoutubePlayerMediaSession mediaSession;
+	private YoutubePlayerMediaSession mediaSession = null;
 
 	public static final String YOUTUBE_VIDEO_OBJ  = "YouTubePlayerActivity.video_object";
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		final boolean useDefaultPlayer = useDefaultPlayer();
-		mediaSession = new YoutubePlayerMediaSession(this);
+		// MediaSession isn't available on SDKs before 21
+		if (Build.VERSION.SDK_INT >= 21) {
+			mediaSession = new YoutubePlayerMediaSession(this);
+		}
 
 		// if the user wants to use the default player, then ensure that the activity does not
 		// have a toolbar (actionbar) -- this is as the fragment is taking care of the toolbar
@@ -170,7 +173,9 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 					+ " must implement YouTubePlayerFragmentInterface");
 		}
 
-		mediaSession.bindToPlayer(fragmentListener);
+		if (mediaSession != null) {
+			mediaSession.bindToPlayer(fragmentListener);
+		}
 		installFragment(videoPlayerFragment);
 	}
 
@@ -192,7 +197,9 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 
 	@Override
 	protected void onStart() {
-		mediaSession.setActive(true);
+		if (mediaSession != null) {
+			mediaSession.setActive(true);
+		}
 		super.onStart();
 
 		// set the video player's orientation as what the user wants
@@ -212,7 +219,10 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 
 	@Override
 	protected void onStop() {
-		mediaSession.setActive(false);
+		if (mediaSession != null) {
+			mediaSession.setActive(false);
+		}
+
 		super.onStop();
 		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 	}
@@ -269,7 +279,9 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 
 	@Override
 	public void finish() {
-		mediaSession.release();
+		if (mediaSession != null) {
+			mediaSession.release();
+		}
 		super.finish();
 	}
 

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -26,8 +26,10 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
+
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+
 import free.rm.skytube.R;
 import free.rm.skytube.app.SkyTubeApp;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubePlaylist;

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -118,7 +118,8 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
-		// media events are handled by MediaSession instead of being passed as keyDown events starting from SDK v21
+		// media events are handled by MediaSession instead of being passed
+		// as keyDown events starting from SDK v21
 		if (Build.VERSION.SDK_INT < 21 && handleMediaKeyDown(keyCode)) {
 			return true;
 		}

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -23,6 +23,7 @@ import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -114,6 +115,18 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 		return true;
 	}
 
+	@Override
+	public boolean onKeyDown(int keyCode, KeyEvent event) {
+		switch (keyCode) {
+			case KeyEvent.KEYCODE_MEDIA_PLAY:
+				fragmentListener.play();
+				return true;
+			case KeyEvent.KEYCODE_MEDIA_PAUSE:
+				fragmentListener.pause();
+				return true;
+		}
+		return super.onKeyDown(keyCode, event);
+	}
 
 	/**
 	 * "Installs" the video player fragment.

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -115,6 +115,7 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 		return true;
 	}
 
+
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
 		// media events are handled by MediaSession instead of being passed as keyDown events starting from SDK v21
@@ -125,6 +126,11 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 		return super.onKeyDown(keyCode, event);
 	}
 
+
+	/**
+	 * Executes appropriate media action for media button key codes.
+	 * @return boolean - whether media action was executed
+	 */
 	public boolean handleMediaKeyDown(int keyCode) {
 		switch (keyCode) {
 			case KeyEvent.KEYCODE_MEDIA_PLAY:
@@ -144,6 +150,7 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 				return false;
 		}
 	}
+
 
 	/**
 	 * "Installs" the video player fragment.
@@ -256,11 +263,13 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 		}
 	}
 
+
 	@Override
 	public void finish() {
 		mediaSession.release();
 		super.finish();
 	}
+
 
 	@Override
 	public void onPlaylistClick(YouTubePlaylist playlist) {}

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -142,6 +142,7 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 			case KeyEvent.KEYCODE_MEDIA_PLAY:
 				fragmentListener.play();
 				return true;
+            case KeyEvent.KEYCODE_MEDIA_STOP:
 			case KeyEvent.KEYCODE_MEDIA_PAUSE:
 				fragmentListener.pause();
 				return true;

--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -124,6 +124,13 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 			case KeyEvent.KEYCODE_MEDIA_PAUSE:
 				fragmentListener.pause();
 				return true;
+			case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+				if (fragmentListener.isPlaying()) {
+					fragmentListener.pause();
+				} else {
+					fragmentListener.play();
+				}
+				return true;
 		}
 		return super.onKeyDown(keyCode, event);
 	}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/MediaSessionHandler.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/MediaSessionHandler.java
@@ -1,0 +1,93 @@
+package free.rm.skytube.gui.businessobjects;
+
+import android.content.Context;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+
+import free.rm.skytube.R;
+import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
+import free.rm.skytube.businessobjects.interfaces.YouTubePlayerFragmentInterface;
+
+
+public final class MediaSessionHandler {
+    private YouTubePlayerFragmentInterface playerFragment;
+    private final MediaSessionCompat mediaSession;
+
+    public MediaSessionHandler(Context context) {
+        mediaSession = new MediaSessionCompat(context, context.getString(R.string.app_name));
+        setupMediaSession();
+    }
+
+    public void attachToPlayer(YouTubePlayerFragmentInterface playerFragment) {
+        this.playerFragment = playerFragment;
+        PlaybackStateListener playbackStateListener = createPlaybackStateListener();
+        playerFragment.setPlaybackStateListener(playbackStateListener);
+    }
+
+    public void setActive(boolean active) {
+        mediaSession.setActive(active);
+    }
+
+    private void setupMediaSession() {
+        MediaSessionCompat.Callback callback = createMediaSessionCallback();
+        mediaSession.setCallback(callback);
+        setActive(true);
+    }
+
+    private MediaSessionCompat.Callback createMediaSessionCallback() {
+        return new MediaSessionCompat.Callback() {
+            @Override
+            public void onPlay() {
+                if (playerFragment != null) {
+                    playerFragment.play();
+                }
+            }
+
+            @Override
+            public void onPause() {
+                if (playerFragment != null) {
+                    playerFragment.pause();
+                }
+            }
+        };
+    }
+
+    private PlaybackStateListener createPlaybackStateListener() {
+        return new PlaybackStateListener() {
+            @Override
+            public void started() {
+                setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+            }
+
+            @Override
+            public void paused() {
+                setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
+            }
+
+            @Override
+            public void ended() {
+                setMediaPlaybackState(PlaybackStateCompat.STATE_STOPPED);
+            }
+
+            private void setMediaPlaybackState(int state) {
+                PlaybackStateCompat playbackState = buildPlaybackState(state);
+                mediaSession.setPlaybackState(playbackState);
+            }
+
+            private PlaybackStateCompat buildPlaybackState(int state) {
+                PlaybackStateCompat.Builder stateBuilder = new PlaybackStateCompat.Builder();
+                stateBuilder.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 0);
+                setPlaybackStateActions(stateBuilder, state);
+                return stateBuilder.build();
+            }
+
+            private void setPlaybackStateActions(PlaybackStateCompat.Builder builder, int state) {
+                if (state == PlaybackStateCompat.STATE_PLAYING) {
+                    builder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PAUSE);
+                } else {
+                    builder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PLAY);
+                }
+            }
+        };
+    }
+}

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
@@ -65,6 +65,11 @@ public final class YoutubePlayerMediaSession {
             public void onPause() {
                 playerFragment.pause();
             }
+
+            @Override
+            public void onStop() {
+                playerFragment.pause();
+            }
         };
     }
 

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
@@ -11,7 +11,8 @@ import free.rm.skytube.businessobjects.interfaces.YouTubePlayerFragmentInterface
 
 /**
  * MediaSessionCompat wrapper.
- * manages the mediaSession and controls YoutubePlayerFragmentInterface upon media session events.
+ * manages the mediaSession and controls YoutubePlayerFragmentInterface
+ * upon media session events.
  */
 public final class YoutubePlayerMediaSession {
     private final MediaSessionCompat mediaSession;

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
@@ -9,21 +9,28 @@ import free.rm.skytube.R;
 import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import free.rm.skytube.businessobjects.interfaces.YouTubePlayerFragmentInterface;
 
-
+/**
+ * MediaSessionCompat wrapper.
+ * manages the mediaSession and controls YoutubePlayerFragmentInterface upon media session events.
+ */
 public final class YoutubePlayerMediaSession {
     private final MediaSessionCompat mediaSession;
+
 
     public YoutubePlayerMediaSession(Context context) {
         mediaSession = new MediaSessionCompat(context, context.getString(R.string.app_name));
     }
 
+
     public void setActive(boolean active) {
         mediaSession.setActive(active);
     }
 
+
     public void release() {
         mediaSession.release();
     }
+
 
     public void bindToPlayer(YouTubePlayerFragmentInterface player) {
         bindPlayerControlCallbacks(player);
@@ -31,15 +38,18 @@ public final class YoutubePlayerMediaSession {
         setActive(true);
     }
 
+
     private void bindPlayerControlCallbacks(YouTubePlayerFragmentInterface player) {
         MediaSessionCompat.Callback callback = createMediaSessionCallback(player);
         mediaSession.setCallback(callback);
     }
 
+
     private void bindPlayerStateListener(YouTubePlayerFragmentInterface player) {
         PlaybackStateListener playbackStateListener = createPlaybackStateListener(mediaSession);
         player.setPlaybackStateListener(playbackStateListener);
     }
+
 
     private MediaSessionCompat.Callback createMediaSessionCallback(YouTubePlayerFragmentInterface player) {
         return new MediaSessionCompat.Callback() {
@@ -57,6 +67,7 @@ public final class YoutubePlayerMediaSession {
         };
     }
 
+
     private PlaybackStateListener createPlaybackStateListener(MediaSessionCompat session) {
         return new PlaybackStateListener() {
             private final MediaSessionCompat mediaSession = session;
@@ -66,20 +77,24 @@ public final class YoutubePlayerMediaSession {
                 setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
             }
 
+
             @Override
             public void paused() {
                 setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
             }
+
 
             @Override
             public void ended() {
                 setMediaPlaybackState(PlaybackStateCompat.STATE_NONE);
             }
 
+
             private void setMediaPlaybackState(int state) {
                 PlaybackStateCompat playbackState = buildPlaybackState(state);
                 mediaSession.setPlaybackState(playbackState);
             }
+
 
             private PlaybackStateCompat buildPlaybackState(int state) {
                 PlaybackStateCompat.Builder stateBuilder = new PlaybackStateCompat.Builder();
@@ -87,6 +102,7 @@ public final class YoutubePlayerMediaSession {
                 stateBuilder.setActions(getPlaybackStateActions(state));
                 return stateBuilder.build();
             }
+
 
             private long getPlaybackStateActions (int state) {
                 if (state == PlaybackStateCompat.STATE_ERROR || state == PlaybackStateCompat.STATE_NONE) {

--- a/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
+++ b/app/src/main/java/free/rm/skytube/gui/businessobjects/YoutubePlayerMediaSession.java
@@ -73,7 +73,7 @@ public final class YoutubePlayerMediaSession {
 
             @Override
             public void ended() {
-                setMediaPlaybackState(PlaybackStateCompat.STATE_STOPPED);
+                setMediaPlaybackState(PlaybackStateCompat.STATE_NONE);
             }
 
             private void setMediaPlaybackState(int state) {
@@ -89,6 +89,10 @@ public final class YoutubePlayerMediaSession {
             }
 
             private long getPlaybackStateActions (int state) {
+                if (state == PlaybackStateCompat.STATE_ERROR || state == PlaybackStateCompat.STATE_NONE) {
+                    return 0;
+                }
+
                 long actions = PlaybackStateCompat.ACTION_PLAY_PAUSE;
 
                 if (state == PlaybackStateCompat.STATE_PLAYING) {

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
@@ -35,6 +35,7 @@ import androidx.preference.PreferenceManager;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
+import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 
@@ -51,7 +52,6 @@ import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeChannel;
 import free.rm.skytube.businessobjects.YouTube.POJOs.YouTubeVideo;
 import free.rm.skytube.businessobjects.YouTube.YouTubeTasks;
 import free.rm.skytube.businessobjects.YouTube.newpipe.ContentId;
-import free.rm.skytube.businessobjects.YouTube.newpipe.NewPipeUtils;
 import free.rm.skytube.businessobjects.db.DatabaseTasks;
 import free.rm.skytube.businessobjects.db.DownloadedVideosDb;
 import free.rm.skytube.businessobjects.db.PlaybackStatusDb;
@@ -134,6 +134,8 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 
 	private static final int MAX_VIDEO_STEP_TIME = 60 * 1000;
 	private static final int MAX_BRIGHTNESS = 100;
+
+	private PlaybackStateListener playbackStateListener;
 
 
 	@Override
@@ -1012,4 +1014,10 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 	public void play() {
 		videoView.start();
 	}
+
+	/**
+	 * no-op, not implemented
+	 */
+	@Override
+	public void setPlaybackStateListener(PlaybackStateListener listener) {}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
@@ -35,7 +35,6 @@ import androidx.preference.PreferenceManager;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
-import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 
@@ -68,6 +67,7 @@ import free.rm.skytube.gui.businessobjects.adapters.CommentsAdapter;
 import free.rm.skytube.gui.businessobjects.fragments.ImmersiveModeFragment;
 import free.rm.skytube.gui.businessobjects.views.Linker;
 import free.rm.skytube.gui.businessobjects.views.SubscribeButton;
+import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import hollowsoft.slidingdrawer.SlidingDrawer;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
@@ -1002,10 +1002,12 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 		return videoView.getCurrentPosition();
 	}
 
+
 	@Override
 	public boolean isPlaying() {
 		return videoView.isPlaying();
 	}
+
 
 	private void stopPlayback() {
 		videoView.pause();
@@ -1016,6 +1018,7 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 		}
 	}
 
+
 	@Override
 	public void pause() {
 		videoView.pause();
@@ -1024,6 +1027,7 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 			playbackStateListener.paused();
 		}
 	}
+
 
 	@Override
 	public void play() {
@@ -1034,9 +1038,7 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 		}
 	}
 
-	/**
-	 * no-op, not implemented
-	 */
+
 	@Override
 	public void setPlaybackStateListener(PlaybackStateListener listener) {
 		playbackStateListener = listener;

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
@@ -999,6 +999,11 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 	}
 
 	@Override
+	public boolean isPlaying() {
+		return videoView.isPlaying();
+	}
+
+	@Override
 	public void pause() {
 		videoView.pause();
 	}

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV1Fragment.java
@@ -1002,4 +1002,9 @@ public class YouTubePlayerV1Fragment extends ImmersiveModeFragment implements Me
 	public void pause() {
 		videoView.pause();
 	}
+
+	@Override
+	public void play() {
+		videoView.start();
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
@@ -25,7 +25,14 @@ import android.graphics.Rect;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.*;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.ExpandableListView;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -57,7 +64,6 @@ import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 
-import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 
@@ -94,6 +100,7 @@ import free.rm.skytube.gui.businessobjects.adapters.CommentsAdapter;
 import free.rm.skytube.gui.businessobjects.fragments.ImmersiveModeFragment;
 import free.rm.skytube.gui.businessobjects.views.Linker;
 import free.rm.skytube.gui.businessobjects.views.SubscribeButton;
+import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import hollowsoft.slidingdrawer.SlidingDrawer;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
@@ -163,6 +163,8 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 	private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 	private Unbinder unbinder;
 
+	private boolean videoIsPlaying;
+
     @Nullable
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -296,7 +298,9 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 				@Override
 				public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
 					Logger.i(this, ">> onPlayerStateChanged " + playWhenReady + " state=" + playbackState);
-					if (playbackState == Player.STATE_READY && playWhenReady) {
+					videoIsPlaying = playbackState == Player.STATE_READY && playWhenReady;
+
+					if (videoIsPlaying) {
 						preventDeviceSleeping(true);
 						playbackSpeedController.updateMenu();
 					} else {
@@ -1149,6 +1153,11 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 	@Override
 	public int getCurrentVideoPosition() {
 		return (int)player.getCurrentPosition();
+	}
+
+	@Override
+	public boolean isPlaying() {
+		return videoIsPlaying;
 	}
 
 	@Override

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
@@ -25,14 +25,7 @@ import android.graphics.Rect;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.Window;
-import android.view.WindowManager;
+import android.view.*;
 import android.widget.ExpandableListView;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -1163,4 +1156,8 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 		player.setPlayWhenReady(false);
 	}
 
+	@Override
+	public void play() {
+		player.setPlayWhenReady(true);
+	}
 }

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
@@ -318,17 +318,14 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 
 					if (playbackStateListener != null) {
 						boolean videoIsPaused = playbackState == Player.STATE_READY && !playWhenReady;
-						sendPlaybackState(videoIsPlaying, videoIsPaused);
-					}
-				}
 
-				private void sendPlaybackState(boolean isPlaying, boolean isPaused) {
-					if(isPlaying) {
-						playbackStateListener.started();
-					} else if (isPaused) {
-						playbackStateListener.paused();
-					} else {
-						playbackStateListener.ended();
+						if(videoIsPlaying) {
+							playbackStateListener.started();
+						} else if (videoIsPaused) {
+							playbackStateListener.paused();
+						} else {
+							playbackStateListener.ended();
+						}
 					}
 				}
 

--- a/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
+++ b/app/src/main/java/free/rm/skytube/gui/fragments/YouTubePlayerV2Fragment.java
@@ -57,6 +57,7 @@ import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 
+import free.rm.skytube.businessobjects.interfaces.PlaybackStateListener;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 
@@ -164,6 +165,7 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 	private Unbinder unbinder;
 
 	private boolean videoIsPlaying;
+	private PlaybackStateListener playbackStateListener = null;
 
     @Nullable
 	@Override
@@ -306,6 +308,21 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 					} else {
 						preventDeviceSleeping(false);
 					}
+
+					if (playbackStateListener != null) {
+						boolean videoIsPaused = playbackState == Player.STATE_READY && !playWhenReady;
+						sendPlaybackState(videoIsPlaying, videoIsPaused);
+					}
+				}
+
+				private void sendPlaybackState(boolean isPlaying, boolean isPaused) {
+					if(isPlaying) {
+						playbackStateListener.started();
+					} else if (isPaused) {
+						playbackStateListener.paused();
+					} else {
+						playbackStateListener.ended();
+					}
 				}
 
 				@Override
@@ -313,6 +330,8 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 					Logger.e(this, ":: onPlayerError " + error.getMessage(), error);
 
 					saveVideoPosition();
+
+					playbackStateListener.ended();
 
 					boolean askForDelete = askForDelete(error);
 					String errorMessage = error.getCause().getMessage();
@@ -1168,5 +1187,10 @@ public class YouTubePlayerV2Fragment extends ImmersiveModeFragment implements Yo
 	@Override
 	public void play() {
 		player.setPlayWhenReady(true);
+	}
+
+	@Override
+	public void setPlaybackStateListener(PlaybackStateListener listener) {
+		playbackStateListener = listener;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/SkyTubeTeam/SkyTube/issues/936

This Pull Request adds play/pause event handling by implementing `MediaSession` on android 21+ and media buttons `keyDown` handling on android < 21. [Dev docs](https://developer.android.com/guide/topics/media-apps/mediabuttons)

---

### New behavior
When sending play/pause events from remote devices (headphones, remote control, etc) the video playback will be paused / resumed.

---

### Testing
- Virtual devices: Android 9.0, 4.4 - play/pause button in DPAD menu works. 
- Physical devices: Android 8.0 with wireless headset controls work as excpected.
- TV: I couldn't get skytube to work on on my android TV, but I don't see why it wouldn't work.
