### PR TITLE
Pause video playback when headphones disconnected

### DIFF
--- a/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
+++ b/app/src/main/java/free/rm/skytube/gui/activities/YouTubePlayerActivity.java
@@ -92,15 +92,17 @@ public class YouTubePlayerActivity extends BaseActivity implements YouTubePlayer
 		receiverRegistered = true;
 	}
 
+
 	private boolean receiverRegistered = false;
 	private final BroadcastReceiver playbackPauseReceiver = new BroadcastReceiver() {
 		@Override
 		public void onReceive(Context context, Intent intent) {
-			if(fragmentListener!= null && fragmentListener.isPlaying()) {
+			if (fragmentListener != null && fragmentListener.isPlaying()) {
 				fragmentListener.pause();
 			}
 		}
 	};
+
 
 	/**
 	 * @return True if the user wants to use SkyTube's default video player;  false if the user wants


### PR DESCRIPTION
Unplugging wired headphones or disconnecting from bluetooth headphones will pause video playback (fixes #435).

Judging by the docs, this should be compatible starting from API level 3.
These changes will work for both of the player types.

### Behavior

Disconnecting wired or bluetooth headphones:
- while video is playing - video is paused.
- while video paused - nothing happens.
- while video is loading (at 00:00) - nothing happens.

If you have both wired and bluetooth headphones connected and you only disconnect one of them then the video is **not** paused.

### Testing
Tested on a physical Android 9 device with both wired and bluetooth headphones.

Checked disconnecting multiple times in one video, switching videos, letting the phone sleep and returning to the app after a while.