### PR TITLE
Dependency bumps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
         exclude group: 'com.google.http-client', module:'google-http-client-jackson2'
     }
 
-    implementation 'com.github.SkyTubeTeam.NewPipeExtractor:extractor:a56daee6b991a63332'
+    implementation 'com.github.SkyTubeTeam.NewPipeExtractor:extractor:d761053c45465c3ee3f'
 
 
     // other modules
@@ -134,20 +134,20 @@ dependencies {
     // Android support modules
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.core:core:1.3.2'
-    implementation 'androidx.media:media:1.2.1'
+    implementation 'androidx.media:media:1.3.0'
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.multidex:multidex:2.0.1' // as we have over 65536 methods...
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     implementation 'com.github.SkyTubeTeam:RxAndroid:3.0.1.SkyTubeTeam'
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.10'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.12'
 
     // debugImplementation because LeakCanary should only run in debug builds.
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 
     // proprietary module
     extraImplementation files('libs/YouTubeAndroidPlayerApi.jar')


### PR DESCRIPTION
 Bump rxjava from 3.0.10 to 3.0.12
 Bump media from 1.2.1 to 1.3.0.
 Bump leakcanary-android from 2.6 to 2.7
 Bump recyclerview from 1.1.0 to 1.2.0

and also a newer newPipeExtractor