### PR TITLE
Use newest version of NewPipeExtractor that fixes javascript function…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,7 @@ dependencies {
         exclude group: 'com.google.http-client', module: 'google-http-client-jackson2'
     }
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.11'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.13'
     implementation ('com.github.SkyTubeTeam.components:okhttp-client:0.0.3') {
         exclude group: 'com.github.SkyTubeTeam.NewPipeExtractor', module: 'extractor'
     }


### PR DESCRIPTION
… name.

For the last day or two I have not been able to view any videos with SkyTube at all, but this update makes them work again. My guess is something at YouTube changed that broke streaming functionality, and luckily NewPipeExtractor was updated to fix this. If others are seeing this problem as well, a new version of SkyTube will need to be released.