### PR TITLE
Minor adjustments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     }
 
     // implementation 'com.github.SkyTubeTeam.NewPipeExtractor:NewPipeExtractor:818745b7e4'
-    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.22.5'
+    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.22.6'
 
     implementation ('com.github.SkyTubeTeam.components:okhttp-client:0.0.5') {
         exclude group: 'com.github.SkyTubeTeam.NewPipeExtractor', module: 'extractor'

--- a/app/src/extra/AndroidManifest.xml
+++ b/app/src/extra/AndroidManifest.xml
@@ -3,8 +3,16 @@
 	xmlns:tools="http://schemas.android.com/tools">
 
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>       <!-- Android Pie now requires this permission to run a foreground service. Chromecast support uses this. See https://developer.android.com/guide/components/services#Foreground -->
+	<!-- for AndroidTV compatibility -->
+	<uses-feature android:name="android.software.leanback"
+		android:required="false" />
+	<uses-feature
+		android:name="android.hardware.touchscreen"
+		android:required="false" />
 
-	<application>
+	<application
+		android:banner="@mipmap/ic_launcher"
+		>
 		<meta-data
 				android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
 				android:value="free.rm.skytube.gui.businessobjects.CastOptionsProvider" />
@@ -15,6 +23,7 @@
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>
+				<category android:name="android.intent.category.LEANBACK_LAUNCHER" />
 			</intent-filter>
 
 		</activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,13 @@
     <!-- [Optional]  If enabled via the preferences, the app will periodically check for new videos published by the subscribed channels -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- for AndroidTV compatibility -->
+    <uses-feature android:name="android.software.leanback"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
     <application
         android:name=".app.SkyTubeApp"
         android:allowBackup="true"
@@ -18,6 +25,7 @@
         android:largeHeap="true"
         android:resizeableActivity="true"
         android:supportsRtl="true"
+        android:banner="@mipmap/ic_launcher"
         android:theme="@style/AppTheme">
         <!-- This will allow the app to use update its self (due to security changes in Android 7.0+) -->
         <provider
@@ -35,8 +43,8 @@
             android:theme="@style/NoActionBarActivityTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Upgrade to the latest NewPipeExtractor, and mark the app as compatible with Android TV.
This is not much, as of now, just it won't be hidden, and the user can add to the main screen.