### PR TITLE
Modified fragment_youtube_player_tutorial.xml and tutorial_play_1.xml

### DIFF
--- a/app/src/main/res/layout/fragment_youtube_player_tutorial.xml
+++ b/app/src/main/res/layout/fragment_youtube_player_tutorial.xml
@@ -50,6 +50,7 @@
 
 		<TextView
 			android:id="@+id/pageCounterTextView"
+			android:textColor="#26ab9e"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:layout_marginBottom="8dp"

--- a/app/src/main/res/layout/tutorial_player_1.xml
+++ b/app/src/main/res/layout/tutorial_player_1.xml
@@ -7,6 +7,7 @@
 
 	<TextView
 		android:text="@string/tutorial_slide_1"
+		android:textColor="#26ab9e"
 		app:layout_constraintBottom_toBottomOf="parent"
 		app:layout_constraintEnd_toStartOf="@+id/view"
 		app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Hello,
I just discovered a color-related issue: the highlighted text is black, which results in insufficient color contrast. This makes it very difficult to read and negatively affects accessibility. Therefore, it should be changed to teal.

before:
![4b](https://github.com/user-attachments/assets/e3af215c-133d-4887-a0be-253cde872253)

after:
![4a](https://github.com/user-attachments/assets/4fa291a1-f738-47f8-90a5-19e63301053b)
