### PR TITLE
AI dubbing issue solved

### DIFF
--- a/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
+++ b/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.AudioTrackType;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 

--- a/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
+++ b/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
@@ -105,7 +105,7 @@ public class StreamSelectionPolicy {
         }
         AudioStream best = null;
         for (AudioStream audioStream : streamInfo.getAudioStreams()) {
-            if (isBetter(best, audioStream)) {
+            if (isOriginalAudio(audioStream) && isBetter(best, audioStream)) {
                 if (BuildConfig.DEBUG) {
                     Logger.d(this, "better %s -> %s", toHumanReadable(best), toHumanReadable(audioStream));
                 }
@@ -120,6 +120,12 @@ public class StreamSelectionPolicy {
 
     private static String toHumanReadable(AudioStream as) {
         return as != null ? "AudioStream(" + as.getAverageBitrate() + ", " + as.getFormat() + ", codec=" + as.getCodec() + ", q=" + as.getQuality() + ", isUrl=" + as.isUrl() + ",delivery=" + as.getDeliveryMethod() + ")" : "NULL";
+    }
+
+    private static boolean isOriginalAudio(AudioStream audioStream) {
+        AudioTrackType trackType = audioStream.getAudioTrackType();
+        // Accept streams with ORIGINAL type, or with null type (unknown/legacy)
+        return trackType == null || trackType == AudioTrackType.ORIGINAL;
     }
 
     private boolean isBetter(AudioStream best, AudioStream other) {


### PR DESCRIPTION
This pull request solves: #1371 #1323 #1369 #1382 #1391


## Description

When reproducing a video, it may sometimes use the AI dubbing audio track to a random language.


## Analysis

I have been reproducing this issue by reproducing videos by their URL. I noticed that it is sensitive to the "Try newer Video formats" option. Disabling this option solves the issue with the audio, but it reproduces a low quality video, due to the system using the legacy video sources.

The bug is in the "pickAudio" method of class "StreamSelectionPolicy". When searching for the best audio stream, by invoking "isBetter", it does not discriminate AI dubbing tracks.


## Solution

I added an auxiliary method "isOriginalAudio", which only accepts original streams ([AudioTrackType](https://pub.dev/documentation/android_new_pipe_extractor/latest/android_new_pipe_extractor/AudioTrackType.html).ORIGINAL) or legacy streams (null).

The "pickAudio" method will search, not only for the best audio stream, but also for an original one.

Having disabled the "Try newer Video formats" option worked because it was forcing the system to take the legacy audio stream.

See commits for further info.


## Considerations for the future

It should be considered, developing a proper option "Use AI dubbing", as well as a combo box for setting an explicit preferred language for AI dubbing.
