### PR TITLE
Fix memory leak related with MediaRouter Callback

### DIFF
--- a/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
+++ b/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.AudioTrackType;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 

--- a/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
+++ b/app/src/main/java/free/rm/skytube/app/StreamSelectionPolicy.java
@@ -105,7 +105,7 @@ public class StreamSelectionPolicy {
         }
         AudioStream best = null;
         for (AudioStream audioStream : streamInfo.getAudioStreams()) {
-            if (isBetter(best, audioStream)) {
+            if (isOriginalAudio(audioStream) && isBetter(best, audioStream)) {
                 if (BuildConfig.DEBUG) {
                     Logger.d(this, "better %s -> %s", toHumanReadable(best), toHumanReadable(audioStream));
                 }
@@ -120,6 +120,12 @@ public class StreamSelectionPolicy {
 
     private static String toHumanReadable(AudioStream as) {
         return as != null ? "AudioStream(" + as.getAverageBitrate() + ", " + as.getFormat() + ", codec=" + as.getCodec() + ", q=" + as.getQuality() + ", isUrl=" + as.isUrl() + ",delivery=" + as.getDeliveryMethod() + ")" : "NULL";
+    }
+
+    private static boolean isOriginalAudio(AudioStream audioStream) {
+        AudioTrackType trackType = audioStream.getAudioTrackType();
+        // Accept streams with ORIGINAL type, or with null type (unknown/legacy)
+        return trackType == null || trackType == AudioTrackType.ORIGINAL;
     }
 
     private boolean isBetter(AudioStream best, AudioStream other) {


### PR DESCRIPTION
### Fix memory leak in `BaseActivity` MediaRouter callback

A persistent leak was occurring (see attached [dump.txt](https://github.com/user-attachments/files/32126918/dump.txt)), and it can be reproduced simply by opening a video and pressing **Back**. Each `YouTubePlayerActivity` instance registered a new anonymous `MediaRouter.Callback` that was never removed, causing destroyed activities to accumulate inside the global `MediaRouter` singleton.

This patch fixes the leak by:

1. Hoisting the anonymous `MediaRouter.Callback` into a dedicated field.
2. Registering it in `onCreate`.
3. Unregistering it in `onDestroy`.

### Why this resolves the leak

- The global `MediaRouter` singleton no longer retains callbacks from destroyed activities. Calling `removeCallback()` breaks the chain: `MainActivity.mediaRouter → mCallbackRecords → CallbackRecord.mCallback → BaseActivity$1 → this$0 = YouTubePlayerActivity`

- Behaviour remains unchanged. The callback’s only responsibility is auto‑selecting the saved Chromecast route for `externalPlayIntent`. It still registers during `onCreate` and lives until `onDestroy`, so auto‑cast behaviour is preserved exactly as before.

### Summary

This is a minimal, behaviour‑preserving fix that eliminates a long‑standing leak by properly pairing `addCallback` with `removeCallback`.
